### PR TITLE
Add segment movement distances

### DIFF
--- a/vignettes/SegmentMovements.Rmd
+++ b/vignettes/SegmentMovements.Rmd
@@ -6,7 +6,7 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEncoding{UTF-8}
-  %\VignetteIndexEntry{Regions interrupting colinearity}
+  %\VignetteIndexEntry{Segment movement distances}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options: 
   chunk_output_type: console


### PR DESCRIPTION
**General**

This vignette adds a few simple functions to evaluate how far segments have moved between a query and a target.

- The function `grMidpoint()` could be useful, which takes a `GRanges` object and just outputs its midpoint. I calculate it in a decidedly un-idiomatic fashion though so it could be improved.

**TODO**
- [ ] Check arm equivalence in addition to chromosome equivalence
- [ ] Try distances on pseudo-scaffolded Kume or Aomori
- [ ] Try distances on genes (`orthoPairs`)