### PR TITLE
Add confidence intervals to RegionWidths

### DIFF
--- a/vignettes/RegionWidths.Rmd
+++ b/vignettes/RegionWidths.Rmd
@@ -160,12 +160,10 @@ Below, I take the `widths_all_tibble` and perform some statistical operations on
 library(dplyr) |> suppressPackageStartupMessages()
 
 t_CI <- function(vector, conf.level){
-  if(length(vector) >= 3){
-    conf_test <- t.test(vector, conf.level = conf.level)
-    conf_str <- paste(round(conf_test$conf.int,2), collapse=',')
-  } else {
-    conf_str <- paste(NA_character_, ',', NA_character_, sep='')
-  }
+  if(length(vector) < 3)
+    return(NA_character_)
+  conf_test <- t.test(vector, conf.level = conf.level)
+  conf_str <- paste(round(conf_test$conf.int,2), collapse=',')
   conf_str
 }
 
@@ -173,12 +171,10 @@ t_CI <- function(vector, conf.level){
 # this test is computationally demanding for large data frames.
 # It works the same as the function above - just slower.
 wilcox_CI <- function(vector, conf.level){
-  if(length(vector) >= 3) {
-    conf_test <- wilcox.test(vector, conf.level = conf.level, conf.int = TRUE)
-    conf_str <- paste(round(conf_test$conf.int,2), collapse=',')
-  } else {
-    conf_str <- paste(NA_character_, ',', NA_character_, sep='')
-  }
+  if(length(vector) < 3)
+     return(NA_character_)
+  conf_test <- wilcox.test(vector, conf.level = conf.level, conf.int = TRUE)
+  conf_str <- paste(round(conf_test$conf.int, 2), collapse=',')
   conf_str
 }
 


### PR DESCRIPTION
This change adds confidence interval estimates for the means of the width statistics. It adds two small functions to generate these intervals that wrap `t.test` (for confidence interval estimates from the t distribution) and `wilcox.test` (for non-parametric confidence interval estimation).

Note that `wilcox.test` is a little slow, I suspect because it requires sorting the data.`t.test` is very fast by comparison, so if there is a need for complex `group_by` statements and many invocations to `wilcox.test`, then I would comment out the line:

```
wilcox_CI = ~wilcox_CI(., conf.level=0.95),
```

unless you are feeling very patient.

I thought about leaving out the `wilcox` bits entirely but IMO it gives more reasonable estimates for the CI given the nature of the data, which are highly non-normal. 